### PR TITLE
fix game_name or gn->n typo

### DIFF
--- a/pynps/functions/functions.py
+++ b/pynps/functions/functions.py
@@ -1014,7 +1014,7 @@ def create_args():
     # check sort list
     if a.sort is not None:
         for i in a.sort.split(","):
-            if i.lower() not in ["c", "id", "r", "t", "gn", "s", "console", "title_id", "region", "type", "game_name", "size"]:
+            if i.lower() not in ["c", "id", "r", "t", "n", "s", "console", "title_id", "region", "type", "game_name", "size"]:
                 printft(HTML("<red>[ERROR] invalid list for --order</red>"))
                 sys.exit(1)
 


### PR DESCRIPTION
Hi. If I want to sort by `game_name`, the manual page say I can use `game_name` or `n`.
```
  -s SORT, --sort SORT  sort search output by column name, can string multiple names by using a comma.  Available options are: console or c, title_id or id, region or r,
                        type or t, game_name or n, size or s. Default value: c,t,r,n
```
Using `game_name` works fine.

Using `n` gives this error.
```python
[ERROR] invalid list for --order
```
Using `gn` gives this error.
```python
Traceback (most recent call last):
  File "~/src/pynps/.venv/bin/pynps", line 33, in <module>
    sys.exit(load_entry_point('pynps', 'console_scripts', 'pynps')())
  File "~/src/pynps/pynps/cli/cli.py", line 291, in cli_main
    maybe_download = search_db(system, what_to_dl, args.search, reg, args.sort, DBFOLDER)
  File "~/~src/pynps/pynps/functions/functions.py", line 579, in search_db
    order = [variables.ORDER_DIC[x] for x in order.split(",")]
  File "~/src/pynps/pynps/functions/functions.py", line 579, in <listcomp>
    order = [variables.ORDER_DIC[x] for x in order.split(",")]
KeyError: 'gn'
```
Simple `gn->n` typo fix. Thank you for this tool. I hope you don't stop working on it. :-) 