### PR TITLE
Fix database search when using Title ID

### DIFF
--- a/pynps/functions/functions.py
+++ b/pynps/functions/functions.py
@@ -556,7 +556,7 @@ def search_db(systems, type, query, region, order, DBFOLDER):
                     else:
                         result = result + [item for item in system_database if 
                                             (item['System'] == system and item['Region'] in region and item['Type'] in types) and 
-                                            (query.lower() in item['Name'].lower() or query.lower() in item['Title ID']) and
+                                            (query.lower() in item['Name'].lower() or query.lower() in item['Title ID'].lower()) and
                                             (item['PKG direct link'] not in ["", "MISSING", None, "CART ONLY"])
                                             ]
                 except:


### PR DESCRIPTION
Searching with Title ID was broken as the query was put in lowercase, but Title ID was still in uppercase. putting Title ID to lowercase using .lower() fixes this issue, and allows bulk searching with Title ID.